### PR TITLE
Also enable PolyKinds in the top-level module

### DIFF
--- a/src/Data/Dependent/Map.hs
+++ b/src/Data/Dependent/Map.hs
@@ -6,6 +6,9 @@
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Safe #-}
 #endif
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE PolyKinds #-}
+#endif
 module Data.Dependent.Map
     ( DMap
     , DSum(..), Some(..)


### PR DESCRIPTION
Otherwise the exported functions are not poly-kinded (for example insert)
