### PR TITLE
Add Lens support for Ix & At for DMap

### DIFF
--- a/dependent-map.cabal
+++ b/dependent-map.cabal
@@ -1,5 +1,5 @@
 name:                   dependent-map
-version:                0.2.5.0
+version:                0.2.5.1
 stability:              provisional
 
 cabal-version:          >= 1.6
@@ -32,7 +32,8 @@ source-repository head
 Library
   hs-source-dirs:       src
   ghc-options:          -fwarn-unused-imports -fwarn-unused-binds
-  exposed-modules:      Data.Dependent.Map
+  exposed-modules:      Data.Dependent.Map,
+                        Data.Dependent.Map.Lens
   other-modules:        Data.Dependent.Map.Internal,
                         Data.Dependent.Map.PtrEquality
   if impl(ghc < 7.8)

--- a/src/Data/Dependent/Map/Lens.hs
+++ b/src/Data/Dependent/Map/Lens.hs
@@ -12,7 +12,7 @@ module Data.Dependent.Map.Lens
 import           Prelude             hiding (lookup)
 
 #if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative (Applicative)
+import           Control.Applicative (Applicative (pure))
 #endif
 
 import           Data.Dependent.Map  (DMap, alterF, insert, lookup)

--- a/src/Data/Dependent/Map/Lens.hs
+++ b/src/Data/Dependent/Map/Lens.hs
@@ -48,6 +48,7 @@ import           Data.GADT.Compare   (GCompare)
 --
 dmat :: (GCompare k, Functor f) => k v -> (Maybe (g v) -> f (Maybe (g v))) -> DMap k g -> f (DMap k g)
 dmat k f = alterF k f
+{-# INLINE dmat #-}
 
 -- |
 -- This is equivalent to the <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-At.html#v:ix ix> <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-Type.html#t:Traversal-39- Traversal'> from <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-At.html Control.Lens.At>:
@@ -83,3 +84,4 @@ dmat k f = alterF k f
 -- Nothing
 dmix :: (GCompare k, Applicative f) => k v -> (g v -> f (g v)) -> DMap k g -> f (DMap k g)
 dmix k f dmap = maybe (pure dmap) (fmap (flip (insert k) dmap) . f) $ lookup k dmap
+{-# INLINE dmix #-}

--- a/src/Data/Dependent/Map/Lens.hs
+++ b/src/Data/Dependent/Map/Lens.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE CPP #-}
+-- |
+-- Some functions for using lenses with 'DMap'.
+module Data.Dependent.Map.Lens
+  ( -- * At
+    dmat
+    -- * Ix
+  , dmix
+  )
+  where
+
+import           Prelude             hiding (lookup)
+
+#if !MIN_VERSION_base(4,8,0)
+import           Control.Applicative (Applicative)
+#endif
+
+import           Data.Dependent.Map  (DMap, alterF, insert, lookup)
+
+import           Data.GADT.Compare   (GCompare)
+
+-- |
+-- These functions have been specialised for use with 'DMap' but without any of the
+-- specific 'lens' types used so that we have compatilibity without needing the
+-- dependency just for these functions.
+--
+
+-- |
+-- This is equivalent to the <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-At.html#v:at at> <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-Type.html#t:Lens-39- Lens'> from <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-At.html Control.Lens.At>:
+--
+-- @
+-- type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+--
+-- at :: Index m -> Lens' m (Maybe (IxValue m))
+-- @
+--
+-- So the type of 'dmat' is equivalent to:
+--
+-- @
+-- dmat :: GCompare k => Lens' (DMap k f) (Maybe (f v))
+-- @
+--
+-- >>> DMap.fromList [AInt :=> Identity 33, AFloat :=> Identity 3.5] & dmat AString ?~ "Hat"
+-- DMap.fromList [AString :=> Identity "Hat", AInt :=> Identity 33, AFloat :=> Identity 3.5]
+--
+-- >>> DMap.fromList [AString :=> Identity "Shoe", AInt :=> Identity 33, AFloat :=> Identity 3.5] ^? dmat AFloat
+-- Just (AFloat :=> 3.5)
+--
+dmat :: (GCompare k, Functor f) => k v -> (Maybe (g v) -> f (Maybe (g v))) -> DMap k g -> f (DMap k g)
+dmat k f = alterF k f
+
+-- |
+-- This is equivalent to the <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-At.html#v:ix ix> <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-Type.html#t:Traversal-39- Traversal'> from <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-At.html Control.Lens.At>:
+--
+-- @
+-- type Traversal s t a b = forall f. Applicative f => (a -> f b) -> s -> f t
+--
+-- ix :: Index m -> Traversal' m (IxValue m)
+-- @
+--
+-- So the type of 'dmix' is equivalent to:
+--
+-- @
+-- dmix :: GCompare k => k v -> Traversal' (DMap k f) (f v)
+-- @
+--
+-- /NB:/ Setting the value of this
+-- <https://hackage.haskell.org/package/lens-4.16.1/docs/Control-Lens-Type.html#t:Traversal Traversal>
+-- will only set the value in 'dmix' if it is already present.
+--
+-- If you want to be able to insert /missing/ values, you want 'dmat'.
+--
+-- >>> DMap.fromList [AString :=> Identity "Shoe", AInt :=> Identity 33, AFloat :=> Identity 3.5] & dmix AInt %~ f
+-- DMap.fromList [AString :=> Identity "Shoe", AInt :=> Identity (f 33), AFloat :=> Identity 3.5]
+--
+-- >>> DMap.fromList [AString :=> Identity "Shoe", AInt :=> Identity 33, AFloat :=> Identity 3.5] & dmix AString .~ "Hat"
+-- DMap.fromList [AString :=> Identity "Hat", AInt :=> Identity 33, AFloat :=> Identity 3.5]
+--
+-- >>> DMap.fromList [AString :=> Identity "Shoe", AInt :=> Identity 33, AFloat :=> Identity 3.5] ^? dmix AFloat
+-- Just (AFloat :=> 3.5)
+--
+-- >>> DMap.fromList [AString :=> Identity "Shoe", AFloat :=> Identity 3.5] ^? dmix AInt
+-- Nothing
+dmix :: (GCompare k, Applicative f) => k v -> (g v -> f (g v)) -> DMap k g -> f (DMap k g)
+dmix k f dmap = maybe (pure dmap) (fmap (flip (insert k) dmap) . f) $ lookup k dmap


### PR DESCRIPTION
The `ix` and `at` lenses are really useful when working with map like structures. But the `At` and `Ixed` type classes rely on a type family that has the wrong kind to be able to work with `DMap`.

These two functions work as their lens counterparts and we don't have to depend on the entire lens package. So there is no penalty if someone is using this package and not using lens.