### PR TITLE
Add Data.Dependent.Map.Internal to exposed-modules.

### DIFF
--- a/dependent-map.cabal
+++ b/dependent-map.cabal
@@ -33,9 +33,9 @@ Library
   hs-source-dirs:       src
   ghc-options:          -fwarn-unused-imports -fwarn-unused-binds
   exposed-modules:      Data.Dependent.Map,
-                        Data.Dependent.Map.Lens
-  other-modules:        Data.Dependent.Map.Internal,
-                        Data.Dependent.Map.PtrEquality
+                        Data.Dependent.Map.Lens,
+                        Data.Dependent.Map.Internal
+  other-modules:        Data.Dependent.Map.PtrEquality
   if impl(ghc < 7.8)
     other-modules:      Data.Dependent.Map.Typeable
   if impl(ghc < 8)


### PR DESCRIPTION
We needed access to the internal structure of the DMap in order to obtain a good pivot for a particularly fiddly transposition operation, so I exposed this module, similarly to how Data.Map does. (Obviously, we'll take responsibility for maintaining our code if DMap's internals change.)