### PR TITLE
Limit problematic use of -trust=* to GHC 7.2.*

### DIFF
--- a/dependent-map.cabal
+++ b/dependent-map.cabal
@@ -43,5 +43,5 @@ Library
   build-depends:        base >= 3 && < 5,
                         containers,
                         dependent-sum >= 0.3.2
-  if impl(ghc >= 7.2) && impl(ghc < 7.8)
+  if impl(ghc == 7.2.*)
     ghc-options:        -trust base -trust dependent-sum


### PR DESCRIPTION
SafeHaskell was known to be broken in GHC 7.2 and that's what this hack is for.

However,  using GHC's `-trust=` breaks in various environments and breaks the
`build-depends`-abstraction; I've observed indeterministically broken builds
because of this.

Using `-trust` on the consumer side is most likely the wrong way anyway, as this
is something that needs to be addressed in the provider, i.e. `dependent-sum`.
Future versions of cabal may actually loudly complain about using `-trust` flags in
`ghc-options`.