### PR TITLE
Build-fix: remove obsolete constructor references.

### DIFF
--- a/dependent-map.cabal
+++ b/dependent-map.cabal
@@ -37,7 +37,7 @@ Library
                         Data.Dependent.Map.Lens,
                         Data.Dependent.Map.Internal
   other-modules:        Data.Dependent.Map.PtrEquality
-  build-depends:        base >= 3 && < 5,
+  build-depends:        base >= 4.9 && < 5,
                         containers >= 0.5.7.1 && <0.7,
                         dependent-sum >= 0.6.1 && < 0.7,
                         constraints-extras >= 0.2.3.0 && < 0.4

--- a/src/Data/Dependent/Map.hs
+++ b/src/Data/Dependent/Map.hs
@@ -153,6 +153,7 @@ import Data.Dependent.Map.Internal
 #if !MIN_VERSION_base(4,7,0)
 import Data.Dependent.Map.Typeable ({- instance Typeable ... -})
 #endif
+import Data.Typeable
 
 import Data.Dependent.Sum
 import Data.Constraint.Extras
@@ -959,7 +960,7 @@ foldlWithKey' f = go
 
 keys  :: DMap k f -> [Some k]
 keys m
-  = [This k | (k :=> _) <- assocs m]
+  = [Some k | (k :=> _) <- assocs m]
 
 -- | /O(n)/. Return all key\/value pairs in the map in ascending key order.
 assocs :: DMap k f -> [DSum k f]
@@ -1234,7 +1235,7 @@ ordered t
     bounded lo hi t'
       = case t' of
           Tip              -> True
-          Bin _ kx _ l r  -> (lo (This kx)) && (hi (This kx)) && bounded lo (< This kx) l && bounded (> This kx) hi r
+          Bin _ kx _ l r  -> (lo (Some kx)) && (hi (Some kx)) && bounded lo (< Some kx) l && bounded (> Some kx) hi r
 
 -- | Exported only for "Debug.QuickCheck"
 balanced :: DMap k f -> Bool

--- a/src/Data/Dependent/Map.hs
+++ b/src/Data/Dependent/Map.hs
@@ -146,13 +146,7 @@ module Data.Dependent.Map
 
 import Prelude hiding (null, lookup, map)
 import qualified Prelude
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative (Applicative(..), (<$>))
-#endif
 import Data.Dependent.Map.Internal
-#if !MIN_VERSION_base(4,7,0)
-import Data.Dependent.Map.Typeable ({- instance Typeable ... -})
-#endif
 import Data.Typeable
 
 import Data.Dependent.Sum
@@ -160,9 +154,6 @@ import Data.Constraint.Extras
 import Data.GADT.Compare
 import Data.GADT.Show
 import Data.Maybe (isJust)
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid
-#endif
 import Data.Semigroup
 import Data.Some
 import Text.Read

--- a/src/Data/Dependent/Map/Internal.hs
+++ b/src/Data/Dependent/Map/Internal.hs
@@ -15,9 +15,7 @@ module Data.Dependent.Map.Internal where
 import Data.Dependent.Sum
 import Data.GADT.Compare
 import Data.Some
-#if MIN_VERSION_base(4,7,0)
 import Data.Typeable (Typeable)
-#endif
 
 -- |Dependent maps: 'k' is a GADT-like thing with a facility for 
 -- rediscovering its type parameter, elements of which function as identifiers
@@ -39,9 +37,7 @@ data DMap k f where
         -> {- left  -} !(DMap k f)
         -> {- right -} !(DMap k f)
         -> DMap k f
-#if MIN_VERSION_base(4,7,0)
     deriving Typeable
-#endif
 
 {--------------------------------------------------------------------
   Construction

--- a/src/Data/Dependent/Map/Internal.hs
+++ b/src/Data/Dependent/Map/Internal.hs
@@ -91,7 +91,7 @@ lookup k = k `seq` go
                 GEQ -> Just x
 
 lookupAssoc :: forall k f v. GCompare k => Some k -> DMap k f -> Maybe (DSum k f)
-lookupAssoc (This k) = k `seq` go
+lookupAssoc (Some k) = k `seq` go
   where
     go :: DMap k f -> Maybe (DSum k f)
     go Tip = Nothing
@@ -344,8 +344,8 @@ bin k x l r
 trim :: (Some k -> Ordering) -> (Some k -> Ordering) -> DMap k f -> DMap k f
 trim _     _     Tip = Tip
 trim cmplo cmphi t@(Bin _ kx _ l r)
-  = case cmplo (This kx) of
-      LT -> case cmphi (This kx) of
+  = case cmplo (Some kx) of
+      LT -> case cmphi (Some kx) of
               GT -> t
               _  -> trim cmplo cmphi l
       _  -> trim cmplo cmphi r
@@ -353,8 +353,8 @@ trim cmplo cmphi t@(Bin _ kx _ l r)
 trimLookupLo :: GCompare k => Some k -> (Some k -> Ordering) -> DMap k f -> (Maybe (DSum k f), DMap k f)
 trimLookupLo _  _     Tip = (Nothing,Tip)
 trimLookupLo lo cmphi t@(Bin _ kx x l r)
-  = case compare lo (This kx) of
-      LT -> case cmphi (This kx) of
+  = case compare lo (Some kx) of
+      LT -> case cmphi (Some kx) of
               GT -> (lookupAssoc lo t, t)
               _  -> trimLookupLo lo cmphi l
       GT -> trimLookupLo lo cmphi r
@@ -369,7 +369,7 @@ filterGt :: GCompare k => (Some k -> Ordering) -> DMap k f -> DMap k f
 filterGt cmp = go
   where
     go Tip              = Tip
-    go (Bin _ kx x l r) = case cmp (This kx) of
+    go (Bin _ kx x l r) = case cmp (Some kx) of
               LT -> combine kx x (go l) r
               GT -> go r
               EQ -> r
@@ -378,7 +378,7 @@ filterLt :: GCompare k => (Some k -> Ordering) -> DMap k f -> DMap k f
 filterLt cmp = go
   where
     go Tip              = Tip
-    go (Bin _ kx x l r) = case cmp (This kx) of
+    go (Bin _ kx x l r) = case cmp (Some kx) of
           LT -> go l
           GT -> combine kx x l (go r)
           EQ -> l

--- a/src/Data/Dependent/Map/Lens.hs
+++ b/src/Data/Dependent/Map/Lens.hs
@@ -11,10 +11,6 @@ module Data.Dependent.Map.Lens
 
 import           Prelude             hiding (lookup)
 
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative (Applicative (pure))
-#endif
-
 import           Data.Dependent.Map  (DMap, alterF, insert, lookup)
 
 import           Data.GADT.Compare   (GCompare)


### PR DESCRIPTION
This fixes the build.  The deprecated constructor This was removed.  It is no longer exported from dependent-sum.  I've replaced all occurrences with Some (which exists since dependent-sum 0.5).  The current lower bound for dependent-sum is 0.6.1.  Additionally, I've dropped support for base < 4.9 because it simplifies maintenance and the dependent-sum bound requires base at least 4.9 anyway.