### PR TITLE
Remove Prelude.filter re-export

### DIFF
--- a/src/Data/Dependent/Map.hs
+++ b/src/Data/Dependent/Map.hs
@@ -101,7 +101,6 @@ module Data.Dependent.Map
     , fromDistinctAscList
 
     -- * Filter
-    , filter
     , filterWithKey
     , partitionWithKey
 


### PR DESCRIPTION
Data.Dependent.Map currently re-exports `filter` from Prelude: https://hackage.haskell.org/package/dependent-map-0.4.0.0/docs/Data-Dependent-Map.html#v:filter

This is because the export list contains `filter`, while the filter operation on the Map type was (of course) removed.

I think the re-export can just be removed, but please be aware that I did not test this PR.

Thanks for the useful package!