### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/dependent-map.cabal
+++ b/dependent-map.cabal
@@ -2,7 +2,7 @@ name:                   dependent-map
 version:                0.4.0.0
 stability:              provisional
 
-cabal-version:          >= 1.6
+cabal-version:          >= 1.8
 build-type:             Simple
 
 author:                 James Cook <mokus@deepbondi.net>


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: dependent-map.cabal:40:39: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```